### PR TITLE
Enhancement: Add slave_id parameter to Modbus tools for dynamic device targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,17 +45,18 @@ The server connects to a Modbus device using parameters specified via environmen
 
 ### Environment Variables
 
-| Variable                | Description                                      | Default              | Required |
-|-------------------------|--------------------------------------------------|----------------------|----------|
-| `MODBUS_TYPE`           | Connection type: `tcp`, `udp`, or `serial`       | `tcp`                | Yes      |
-| `MODBUS_HOST`           | Host address for TCP/UDP                        | `127.0.0.1`          | For TCP/UDP |
-| `MODBUS_PORT`           | Port for TCP/UDP                                | `502`                | For TCP/UDP |
-| `MODBUS_SERIAL_PORT`    | Serial port (e.g., `/dev/ttyUSB0`, `COM1`)      | `/dev/ttyUSB0`       | For serial |
-| `MODBUS_BAUDRATE`       | Serial baud rate                                | `9600`               | For serial |
-| `MODBUS_PARITY`         | Serial parity: `N` (none), `E` (even), `O` (odd) | `N`                 | For serial |
-| `MODBUS_STOPBITS`       | Serial stop bits                                | `1`                  | For serial |
-| `MODBUS_BYTESIZE`       | Serial byte size                                | `8`                  | For serial |
-| `MODBUS_TIMEOUT`        | Serial timeout (seconds)                        | `1`                  | For serial |
+| Variable                   | Description                                      | Default              | Required |
+|-------------------------   |--------------------------------------------------|----------------------|----------|
+| `MODBUS_TYPE`              | Connection type: `tcp`, `udp`, or `serial`       | `tcp`                | Yes      |
+| `MODBUS_HOST`              | Host address for TCP/UDP                        | `127.0.0.1`          | For TCP/UDP |
+| `MODBUS_PORT`              | Port for TCP/UDP                                | `502`                | For TCP/UDP |
+| `MODBUS_DEFAULT_SLAVE_ID`  | Slave ID                                        | `1`                  | For TCP/UDP |
+| `MODBUS_SERIAL_PORT`       | Serial port (e.g., `/dev/ttyUSB0`, `COM1`)      | `/dev/ttyUSB0`       | For serial |
+| `MODBUS_BAUDRATE`          | Serial baud rate                                | `9600`               | For serial |
+| `MODBUS_PARITY`            | Serial parity: `N` (none), `E` (even), `O` (odd) | `N`                 | For serial |
+| `MODBUS_STOPBITS`          | Serial stop bits                                | `1`                  | For serial |
+| `MODBUS_BYTESIZE`          | Serial byte size                                | `8`                  | For serial |
+| `MODBUS_TIMEOUT`           | Serial timeout (seconds)                        | `1`                  | For serial |
 
 ### Example `.env` File
 
@@ -64,6 +65,7 @@ For TCP:
 MODBUS_TYPE=tcp
 MODBUS_HOST=192.168.1.100
 MODBUS_PORT=502
+MODBUS_SLAVE_ID=1
 ```
 
 For Serial:
@@ -108,7 +110,7 @@ The configuration file:
      ```json
      {
        "tool": "read_register",
-       "parameters": {"address": 0}
+       "parameters": {"address": 0, "slave_id": 1}
      }
      ```
    - **Expected Output**: `Value: <register_value>`
@@ -122,7 +124,7 @@ The configuration file:
      ```json
      {
        "tool": "write_register",
-       "parameters": {"address": 10, "value": 100}
+       "parameters": {"address": 10, "value": 100, `slave_id`: `1`}
      }
      ```
    - **Expected Output**: `Successfully wrote 100 to register 10`
@@ -136,7 +138,7 @@ The configuration file:
      ```json
      {
        "tool": "read_coils",
-       "parameters": {"address": 0, "count": 5}
+       "parameters": {"address": 0, "count": 5, `slave_id`: `1`}
      }
      ```
    - **Expected Output**: `Coils 0 to 4: [False, False, False, False, False]`
@@ -150,7 +152,7 @@ The configuration file:
      ```json
      {
        "tool": "write_coil",
-       "parameters": {"address": 5, "value": true}
+       "parameters": {"address": 5, "value": true, `slave_id`: `1`}
      }
      ```
    - **Expected Output**: `Successfully wrote True to coil 5`
@@ -164,7 +166,7 @@ The configuration file:
      ```json
      {
        "tool": "read_input_registers",
-       "parameters": {"address": 2, "count": 3}
+       "parameters": {"address": 2, "count": 3, `slave_id`: `1`}
      }
      ```
    - **Expected Output**: `Input Registers 2 to 4: [<value1>, <value2>, <value3>]`
@@ -178,7 +180,7 @@ The configuration file:
      ```json
      {
        "tool": "read_multiple_holding_registers",
-       "parameters": {"address": 0, "count": 3}
+       "parameters": {"address": 0, "count": 3, `slave_id`: `1`}
      }
      ```
    - **Expected Output**: `Holding Registers 0 to 2: [<value1>, <value2>, <value3>]`

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The configuration file:
      ```json
      {
        "tool": "write_register",
-       "parameters": {"address": 10, "value": 100, `slave_id`: `1`}
+       "parameters": {"address": 10, "value": 100, "slave_id": 1}
      }
      ```
    - **Expected Output**: `Successfully wrote 100 to register 10`
@@ -138,7 +138,7 @@ The configuration file:
      ```json
      {
        "tool": "read_coils",
-       "parameters": {"address": 0, "count": 5, `slave_id`: `1`}
+       "parameters": {"address": 0, "count": 5, "slave_id": 1}
      }
      ```
    - **Expected Output**: `Coils 0 to 4: [False, False, False, False, False]`
@@ -152,7 +152,7 @@ The configuration file:
      ```json
      {
        "tool": "write_coil",
-       "parameters": {"address": 5, "value": true, `slave_id`: `1`}
+       "parameters": {"address": 5, "value": true, "slave_id": 1}
      }
      ```
    - **Expected Output**: `Successfully wrote True to coil 5`
@@ -166,7 +166,7 @@ The configuration file:
      ```json
      {
        "tool": "read_input_registers",
-       "parameters": {"address": 2, "count": 3, `slave_id`: `1`}
+       "parameters": {"address": 2, "count": 3, "slave_id": 1}
      }
      ```
    - **Expected Output**: `Input Registers 2 to 4: [<value1>, <value2>, <value3>]`
@@ -180,7 +180,7 @@ The configuration file:
      ```json
      {
        "tool": "read_multiple_holding_registers",
-       "parameters": {"address": 0, "count": 3, `slave_id`: `1`}
+       "parameters": {"address": 0, "count": 3, "slave_id": 1}
      }
      ```
    - **Expected Output**: `Holding Registers 0 to 2: [<value1>, <value2>, <value3>]`

--- a/src/modbus_mcp/cli.py
+++ b/src/modbus_mcp/cli.py
@@ -92,37 +92,40 @@ async def read_register(address: int, ctx: Context, slave_id: int = MODBUS_DEFAU
         return f"Error communicating with slave {slave_id}: {str(e)}"
 
 @mcp.tool()
-async def write_register(address: int, value: int, ctx: Context) -> str:
+async def write_register(address: int, value: int, ctx: Context, slave_id: int = MODBUS_DEFAULT_SLAVE_ID) -> str: # 修改點 1
     """
     Write a value to a Modbus holding register.
 
     Parameters:
         address (int): The address of the holding register (0-65535).
         value (int): The value to write (0-65535).
-    
+        slave_id (int): The Modbus slave ID (device ID).
+
     Returns:
         str: Success message or an error message.
     """
     client = ctx.request_context.lifespan_context.modbus_client
     try:
-        result = await client.write_register(address=address, value=value, slave=1)
+        # 修改點 2
+        result = await client.write_register(address=address, value=value, slave=slave_id)
         if result.isError():
-            return f"Error writing to register {address}: {result}"
-        ctx.info(f"Wrote {value} to register {address}")
-        return f"Successfully wrote {value} to register {address}"
+            return f"Error writing to register {address} on slave {slave_id}: {result}"
+        ctx.info(f"Wrote {value} to register {address} on slave {slave_id}")
+        return f"Successfully wrote {value} to register {address} on slave {slave_id}"
     except ModbusException as e:
-        return f"Error: {str(e)}"
+        return f"Error communicating with slave {slave_id}: {str(e)}"
 
 # Tools: Coil operations
 @mcp.tool()
-async def read_coils(address: int, count: int, ctx: Context) -> str:
+async def read_coils(address: int, count: int, ctx: Context, slave_id: int = MODBUS_DEFAULT_SLAVE_ID) -> str: # 修改點 1
     """
     Read the status of multiple Modbus coils.
 
     Parameters:
         address (int): The starting address of the coils (0-65535).
         count (int): The number of coils to read (1-2000).
-    
+        slave_id (int): The Modbus slave ID (device ID).
+
     Returns:
         str: A list of coil states (True/False) or an error message.
     """
@@ -130,46 +133,50 @@ async def read_coils(address: int, count: int, ctx: Context) -> str:
     try:
         if count <= 0:
             return "Error: Count must be positive"
-        result = await client.read_coils(address=address, count=count, slave=1)
+        # 修改點 2
+        result = await client.read_coils(address=address, count=count, slave=slave_id)
         if result.isError():
-            return f"Error reading coils starting at {address}: {result}"
-        ctx.info(f"Read {count} coils starting at {address}: {result.bits}")
-        return f"Coils {address} to {address+count-1}: {result.bits[:count]}"
+            return f"Error reading coils starting at {address} from slave {slave_id}: {result}"
+        ctx.info(f"Read {count} coils starting at {address} from slave {slave_id}: {result.bits}")
+        return f"Slave {slave_id}, Coils {address} to {address+count-1}: {result.bits[:count]}"
     except ModbusException as e:
-        return f"Error: {str(e)}"
+        return f"Error communicating with slave {slave_id}: {str(e)}"
 
 @mcp.tool()
-async def write_coil(address: int, value: bool, ctx: Context) -> str:
+async def write_coil(address: int, value: bool, ctx: Context, slave_id: int = MODBUS_DEFAULT_SLAVE_ID) -> str: # 修改點 1
     """
     Write a value to a single Modbus coil.
 
     Parameters:
         address (int): The address of the coil (0-65535).
         value (bool): The value to write (True for ON, False for OFF).
-    
+        slave_id (int): The Modbus slave ID (device ID).
+
     Returns:
         str: Success message or an error message.
     """
     client = ctx.request_context.lifespan_context.modbus_client
     try:
-        result = await client.write_coil(address=address, value=value, slave=1)
+        # 修改點 2
+        result = await client.write_coil(address=address, value=value, slave=slave_id)
         if result.isError():
-            return f"Error writing to coil {address}: {result}"
-        ctx.info(f"Wrote {value} to coil {address}")
-        return f"Successfully wrote {value} to coil {address}"
+            return f"Error writing to coil {address} on slave {slave_id}: {result}"
+        ctx.info(f"Wrote {value} to coil {address} on slave {slave_id}")
+        return f"Successfully wrote {value} to coil {address} on slave {slave_id}"
     except ModbusException as e:
-        return f"Error: {str(e)}"
+        return f"Error communicating with slave {slave_id}: {str(e)}"
 
 # Tools: Input registers
 @mcp.tool()
-async def read_input_registers(address: int, count: int, ctx: Context) -> str:
+async def read_input_registers(address: int, count: int, ctx: Context, slave_id: int = MODBUS_DEFAULT_SLAVE_ID) -> str: # 修改點 1
     """
     Read multiple Modbus input registers.
 
     Parameters:
         address (int): The starting address of the input registers (0-65535).
         count (int): The number of registers to read (1-125).
-    
+        slave_id (int): The Modbus slave ID (device ID).
+
     Returns:
         str: A list of register values or an error message.
     """
@@ -177,24 +184,26 @@ async def read_input_registers(address: int, count: int, ctx: Context) -> str:
     try:
         if count <= 0:
             return "Error: Count must be positive"
-        result = await client.read_input_registers(address=address, count=count, slave=1)
+        # 修改點 2
+        result = await client.read_input_registers(address=address, count=count, slave=slave_id)
         if result.isError():
-            return f"Error reading input registers starting at {address}: {result}"
-        ctx.info(f"Read {count} input registers starting at {address}: {result.registers}")
-        return f"Input Registers {address} to {address+count-1}: {result.registers}"
+            return f"Error reading input registers starting at {address} from slave {slave_id}: {result}"
+        ctx.info(f"Read {count} input registers starting at {address} from slave {slave_id}: {result.registers}")
+        return f"Slave {slave_id}, Input Registers {address} to {address+count-1}: {result.registers}"
     except ModbusException as e:
-        return f"Error: {str(e)}"
+        return f"Error communicating with slave {slave_id}: {str(e)}"
 
 # Tools: Read multiple holding registers
 @mcp.tool()
-async def read_multiple_holding_registers(address: int, count: int, ctx: Context) -> str:
+async def read_multiple_holding_registers(address: int, count: int, ctx: Context, slave_id: int = MODBUS_DEFAULT_SLAVE_ID) -> str: # 修改點 1
     """
     Read multiple Modbus holding registers.
 
     Parameters:
         address (int): The starting address of the holding registers (0-65535).
         count (int): The number of registers to read (1-125).
-    
+        slave_id (int): The Modbus slave ID (device ID).
+
     Returns:
         str: A list of register values or an error message.
     """
@@ -202,14 +211,14 @@ async def read_multiple_holding_registers(address: int, count: int, ctx: Context
     try:
         if count <= 0:
             return "Error: Count must be positive"
-        result = await client.read_holding_registers(address=address, count=count, slave=1)
+        # 修改點 2
+        result = await client.read_holding_registers(address=address, count=count, slave=slave_id)
         if result.isError():
-            return f"Error reading holding registers starting at {address}: {result}"
-        ctx.info(f"Read {count} holding registers starting at {address}: {result.registers}")
-        return f"Holding Registers {address} to {address+count-1}: {result.registers}"
+            return f"Error reading holding registers starting at {address} from slave {slave_id}: {result}"
+        ctx.info(f"Read {count} holding registers starting at {address} from slave {slave_id}: {result.registers}")
+        return f"Slave {slave_id}, Holding Registers {address} to {address+count-1}: {result.registers}"
     except ModbusException as e:
-        return f"Error: {str(e)}"
-
+        return f"Error communicating with slave {slave_id}: {str(e)}"
 
 # Prompts: Templates for Modbus interactions
 @mcp.prompt()


### PR DESCRIPTION
**Related Issue:** (If this PR addresses a specific issue, link it here, e.g., Fixes #123)

**Description:**

This pull request introduces the ability to specify the Modbus `slave_id` (device ID) when calling Modbus tool functions. Previously, the slave ID was often hardcoded (e.g., to 1), limiting interactions to a single pre-defined device on the Modbus network.

**Changes Made:**

* Added an optional `slave_id` parameter to the following Modbus tool functions:
    * `read_register`
    * `write_register`
    * `read_coils`
    * `write_coil`
    * `read_input_registers`
    * `read_multiple_holding_registers`
* The `slave_id` parameter is passed down to the underlying `pymodbus` client calls, allowing communication with the specified device.
* If `slave_id` is not provided by the caller, a default value (e.g., configured via an environment variable like `MODBUS_DEFAULT_SLAVE_ID` or a hardcoded default in the function signature) is used, maintaining backward compatibility for existing calls that do not specify a slave ID.
* Updated `README.md` to document the new `slave_id` parameter, its usage, and how to configure the default slave ID (if applicable).

This enhancement should significantly improve the capabilities of the Modbus integration within this MCP server.